### PR TITLE
security(iac): require env-based credentials; refine quickstart

### DIFF
--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -1,42 +1,64 @@
+# Sekretesskanning med Gitleaks
 name: Secret Scan
 
 on:
+  # Kör på push till huvudgrenarna där du arbetar
   push:
-    branches: [ "main", "test" ]
-    paths-ignore: [ "**/*.md", "docs/**" ]    # ignorera Markdown och dokumentation
+    branches: [ "main", "test" ]  # vilka branches som triggar vid push
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+  # Kör på pull requests riktade mot main (blockerar merge vid träffar)
   pull_request:
-    branches: [ "main" ]                      # PR:er mot main
+    branches: [ "main" ]
+  # Veckovis säkerhetsnät: måndagar kl 03:00 UTC
   schedule:
-    - cron: "0 3 * * 1"                       # veckovis skyddsnät (måndagar 03:00 UTC)
+    - cron: "0 3 * * 1"
+  # Möjliggör manuell körning från Actions-fliken
   workflow_dispatch:
 
+# Förhindrar överlappande körningar på samma gren
 concurrency:
-  group: secret-scan-${{ github.ref }}        # undvik parallella körningar per gren
-  cancel-in-progress: true
+  group: secret-scan-${{ github.ref }}  # en kö per referens (branch/tag)
+  cancel-in-progress: true              # avbryt pågående om en ny startar
 
 jobs:
-  gitleaks:                                    # check-namn (visas i PR)
+  gitleaks:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
 
     steps:
+      # Klonar källan; fetch-depth: 0 krävs för full historikskanning
       - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }               # krävs för fullständig skanning (git-historik)
+        with:
+          fetch-depth: 0
 
-      # PR: snabb skanning — blockerar merge om hemlighet hittas
+      # PR: snabb skanning (endast arbetskatalog, utan git-historik)
+      # Syfte: snabb feedback och möjligheten att blockera merge direkt
       - name: Gitleaks (PR - fast)
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request'   # kör enbart på PR-event
         uses: gitleaks/gitleaks-action@v2
         with:
-          args: detect --source=. --no-git --redact --verbose --config-path=.gitleaks.toml
-        env: { GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} }
+          # Flaggor i citerad, flerradig sträng för robust YAML-parsning
+          # Actionen anropar 'detect' internt; här skickas endast flaggor
+          args: >-
+            --no-git --redact --verbose
+            --source .
+            --config-path=.gitleaks.toml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # krävs för PR-autentisering
 
-      # push/schedule: fullständig skanning — genomsöker hela historiken
+      # Push/schedule: fullständig skanning (med git-historik)
+      # Syfte: djupare kontroll efter merge och vid schemalagda körningar
       - name: Gitleaks (push/schedule - full)
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'     # kör ej på PR-event
         uses: gitleaks/gitleaks-action@v2
         with:
-          args: detect --source=. --redact --verbose --config-path=.gitleaks.toml
-        env: { GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} }
+          args: >-
+            --redact --verbose
+            --source .
+            --config-path=.gitleaks.toml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -50,7 +50,7 @@ jobs:
           gitleaks detect \
             --no-git --redact --verbose \
             --source . \
-            --config-path .gitleaks.toml
+            -c .gitleaks.toml
 
       # push/schedule: fullständig skanning — genomsöker hela historiken
       - name: Installera Gitleaks (full)
@@ -67,6 +67,6 @@ jobs:
           gitleaks detect \
             --redact --verbose \
             --source . \
-            --config-path .gitleaks.toml
+            -c .gitleaks.toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -28,6 +28,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      security-events: write
 
     steps:
       # Klonar källan; fetch-depth: 0 krävs för full historikskanning
@@ -52,21 +53,32 @@ jobs:
             --source . \
             -c .gitleaks.toml
 
-      # push/schedule: fullständig skanning — genomsöker hela historiken
-      - name: Installera Gitleaks (full)
+        # Full skanning + generera SARIF (endast på push/schedule, inte PR)
+      - name: Gitleaks (push/schedule - full, SARIF)
         if: github.event_name != 'pull_request'
-        run: |
-          set -e
-          V="8.18.4"
-          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${V}/gitleaks_${V}_linux_x64.tar.gz" \
-            | tar -xz
-          sudo mv gitleaks /usr/local/bin/gitleaks
-      - name: Gitleaks (push/schedule - full)
-        if: github.event_name != 'pull_request'
+        id: gitleaks_full
+        continue-on-error: true   # fortsätt så vi kan ladda upp rapporten
         run: |
           gitleaks detect \
             --redact --verbose \
             --source . \
-            -c .gitleaks.toml
+            -c .gitleaks.toml \
+            --report-format sarif \
+            --report-path gitleaks-results.sarif
+
+      # Ladda upp SARIF till Security → Code scanning (endast på main)
+      - name: Upload SARIF to Code scanning
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: gitleaks-results.sarif
+
+      # Misslyckas om skanningen hittade läckor
+      - name: Fail on findings
+        if: steps.gitleaks_full.outcome == 'failure'
+        run: |
+          echo "Gitleaks found secrets. Failing the job."
+          exit 1
+
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -53,6 +53,16 @@ jobs:
             --source . \
             -c .gitleaks.toml
 
+      # Full skanning kräver CLI även här
+      - name: Installera Gitleaks (full)
+        if: github.event_name != 'pull_request'
+        run: |
+          set -e
+          V="8.18.4"
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${V}/gitleaks_${V}_linux_x64.tar.gz" \
+            | tar -xz
+          sudo mv gitleaks /usr/local/bin/gitleaks
+
         # Full skanning + generera SARIF (endast på push/schedule, inte PR)
       - name: Gitleaks (push/schedule - full, SARIF)
         if: github.event_name != 'pull_request'

--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           fetch-depth: 0
 
-          # PR: snabb skanning — blockerar merge om hemlighet hittas
+        # PR: snabb skanning — blockerar merge om hemlighet hittas
       - name: Installera Gitleaks (PR)
         if: github.event_name == 'pull_request'
         run: |

--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -35,30 +35,38 @@ jobs:
         with:
           fetch-depth: 0
 
-      # PR: snabb skanning (endast arbetskatalog, utan git-historik)
-      # Syfte: snabb feedback och möjligheten att blockera merge direkt
+          # PR: snabb skanning — blockerar merge om hemlighet hittas
+      - name: Installera Gitleaks (PR)
+        if: github.event_name == 'pull_request'
+        run: |
+          set -e
+          V="8.18.4"
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${V}/gitleaks_${V}_linux_x64.tar.gz" \
+            | tar -xz
+          sudo mv gitleaks /usr/local/bin/gitleaks
       - name: Gitleaks (PR - fast)
-        if: github.event_name == 'pull_request'   # kör enbart på PR-event
-        uses: gitleaks/gitleaks-action@v2
-        with:
-          # Flaggor i citerad, flerradig sträng för robust YAML-parsning
-          # Actionen anropar 'detect' internt; här skickas endast flaggor
-          args: >-
-            --no-git --redact --verbose
-            --source .
-            --config-path=.gitleaks.toml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # krävs för PR-autentisering
+        if: github.event_name == 'pull_request'
+        run: |
+          gitleaks detect \
+            --no-git --redact --verbose \
+            --source . \
+            --config-path .gitleaks.toml
 
-      # Push/schedule: fullständig skanning (med git-historik)
-      # Syfte: djupare kontroll efter merge och vid schemalagda körningar
+      # push/schedule: fullständig skanning — genomsöker hela historiken
+      - name: Installera Gitleaks (full)
+        if: github.event_name != 'pull_request'
+        run: |
+          set -e
+          V="8.18.4"
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${V}/gitleaks_${V}_linux_x64.tar.gz" \
+            | tar -xz
+          sudo mv gitleaks /usr/local/bin/gitleaks
       - name: Gitleaks (push/schedule - full)
-        if: github.event_name != 'pull_request'     # kör ej på PR-event
-        uses: gitleaks/gitleaks-action@v2
-        with:
-          args: >-
-            --redact --verbose
-            --source .
-            --config-path=.gitleaks.toml
+        if: github.event_name != 'pull_request'
+        run: |
+          gitleaks detect \
+            --redact --verbose \
+            --source . \
+            --config-path .gitleaks.toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -2,30 +2,41 @@ name: Secret Scan
 
 on:
   push:
-    branches: [ "main", "test", "**feature/**" ]
-    paths-ignore:
-      - "**/*.md"         # ignorera markdown
-      - "docs/**"         # ignorera dokumentation
+    branches: [ "main", "test" ]
+    paths-ignore: [ "**/*.md", "docs/**" ]    # ignorera Markdown och dokumentation
   pull_request:
+    branches: [ "main" ]                      # PR:er mot main
   schedule:
-    - cron: "0 3 * * 1"   # måndag 03:00 UTC (veckovis säkerhetsnät)
+    - cron: "0 3 * * 1"                       # veckovis skyddsnät (måndagar 03:00 UTC)
   workflow_dispatch:
 
+concurrency:
+  group: secret-scan-${{ github.ref }}        # undvik parallella körningar per gren
+  cancel-in-progress: true
+
 jobs:
-  gitleaks:
+  gitleaks:                                    # check-namn (visas i PR)
     runs-on: ubuntu-latest
-    # Viktigt: ge rättigheter för att läsa PR-innehåll
     permissions:
       contents: read
       pull-requests: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0   # skanna hela git-historiken
 
-      - name: Gitleaks (enforce, fail on findings)
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }               # krävs för fullständig skanning (git-historik)
+
+      # PR: snabb skanning — blockerar merge om hemlighet hittas
+      - name: Gitleaks (PR - fast)
+        if: github.event_name == 'pull_request'
         uses: gitleaks/gitleaks-action@v2
-        # Viktigt: ge GITHUB_TOKEN till actionen för PR-event
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: detect --source=. --no-git --redact --verbose --config-path=.gitleaks.toml
+        env: { GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} }
+
+      # push/schedule: fullständig skanning — genomsöker hela historiken
+      - name: Gitleaks (push/schedule - full)
+        if: github.event_name != 'pull_request'
+        uses: gitleaks/gitleaks-action@v2
+        with:
+          args: detect --source=. --redact --verbose --config-path=.gitleaks.toml
+        env: { GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} }

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,16 +1,16 @@
 title = "Custom Gitleaks config"
 
-# Huvudnivå allowlist (map), inte lista [[allowlist]]
+# Global allowlist (gäller för hela repo:t)
 [allowlist]
-description = "Ignorera exempel/test-konfigfiler och vanliga placeholders"
+description = "Ignorera exempel-/testfiler och vanliga placeholders"
 
-# Filer som ska ignoreras för att undvika falsklarm
+# Filer att ignorera (regex på filnamn/sökväg)
 files = [
-    ".env.example",
-    ".*application-test.properties"
+    ".env.example",                 # endast exempel, inga riktiga hemligheter
+    ".*application-test\\.properties" # test-konfig (H2/JMS), inga secrets här
 ]
 
-# Vanliga strängar (placeholders) som inte ska räknas som hemligheter
+# Vanliga strängar som inte ska räknas som hemligheter
 regexes = [
     '''(?i)changeme''',
     '''(?i)to-be-set''',

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,9 +4,11 @@ services:
   postgres:
     image: postgres:13
     container_name: postgres
+    # Läser variabler från .env för substitutions (Compose läser .env i projektroten).
+    # Kräver lösenord: stoppar tidigt om DB_PASSWORD saknas.
     environment:
       POSTGRES_USER: ${DB_USER:-integration}
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:?Set DB_PASSWORD in .env}   # <-- krävs
       POSTGRES_DB: ${DB_NAME:-integrationdb}
     volumes:
       - postgres_data:/var/lib/postgresql/data
@@ -35,6 +37,9 @@ services:
   integration-app:
     image: igor88gomes/spring-boot-integration:latest
     container_name: integration-app
+    # Läser DB_* och BROKER_* från .env in i containern (krävs av Spring)
+    env_file:
+      - .env                               # <-- lägg .env i projektroten
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     container_name: postgres
     environment:
       POSTGRES_USER: ${DB_USER:-integration}
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-integration_pass}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_DB: ${DB_NAME:-integrationdb}
     volumes:
       - postgres_data:/var/lib/postgresql/data

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -25,21 +25,30 @@ Om du använder **Podman**, ersätt helt enkelt `docker` med `podman` och
 git clone https://github.com/igor88gomes/spring-boot-integration.git
 cd spring-boot-integration
 ```
-### 2) Bygg och starta stacken (app + ActiveMQ + PostgreSQL)
+
+### 2) Kopiera mallfilen `.env.example` till en lokal `.env` (obligatoriskt för att starta stacken) 
+
+```bash
+cp .env.example .env
+```
+
+> Rekommenderat: fyll i skarpa värden i .env för ökad säkerhet (ignoreras av Git). I övrigt räcker kopieringen från `.env.example` till `.env`
+
+### 3) Bygg och starta stacken (app + ActiveMQ + PostgreSQL)
 
 ```bash
 docker compose up --build -d
 # alt: podman-compose up --build -d
 ```
 
-### 3) Kontrollera körande containrar
+### 4) Kontrollera körande containrar
 
 ```bash
 docker ps
 # alt: podman ps
 ```
 
-### 4) Stoppa och rensa nätverk/containers
+### 5) Stoppa och rensa nätverk/containers
 
 ```bash
 docker compose down
@@ -268,23 +277,6 @@ Alla artifacts hämtas via **Actions** i GitHub:
 > Tips: Du hittar även digesten och multi-arch-info via `docker buildx imagetools inspect <image>:<tag>` om du vill dubbelkolla promotionen.
 
 ---
-
-## Miljövariabler (valfritt)
-
-`.env` är **valfritt**. Om filen saknas körs stacken med interna dev-standarder.  
-Vill du anpassa konfigurationen, skapa en lokal `.env`.
-
-## Miljövariabler
-
-Skapa en lokal **`.env`** för din miljö. Se **`.env.example`** som mall.  
-Inga standardvärden kontrolleras in i koden.
-
-Nycklar som stöds:
-- `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`
-- `BROKER_URL`, `BROKER_USER`, `BROKER_PASS`
-- `APP_QUEUE_NAME`
-
-```
 
 > **Obs:** Pipelines och artifacts är fullt fungerande i detta repo och kan granskas direkt via **Actions**-fliken.  
 > Vid automatiska tester i CI används en in-memory **H2**-databas istället för PostgreSQL för snabbare körning och enklare underhåll.  

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -274,29 +274,16 @@ Alla artifacts hämtas via **Actions** i GitHub:
 `.env` är **valfritt**. Om filen saknas körs stacken med interna dev-standarder.  
 Vill du anpassa konfigurationen, skapa en lokal `.env`.
 
-**Obs:** `.env.example` finns i repot som mall. Filer som börjar med punkt kan vara dolda. Visa dem t.ex. i Linux/macOS  med `ls -la` eller i Windows PowerShell med `ls -Force`.
+## Miljövariabler
 
-### Rensa nycklar (utan defaults)
+Skapa en lokal **`.env`** för din miljö. Se **`.env.example`** som mall.  
+Inga standardvärden kontrolleras in i koden.
+
+Nycklar som stöds:
 - `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`
 - `BROKER_URL`, `BROKER_USER`, `BROKER_PASS`
 - `APP_QUEUE_NAME`
 
-**Exempel – `.env` med platshållare (redigera värdena):**
-```dotenv
-# Database
-DB_HOST=<host>
-DB_PORT=<port>
-DB_NAME=<dbname>
-DB_USER=<user>
-DB_PASSWORD=<password>
-
-# ActiveMQ
-BROKER_URL=<tcp://host:port>
-BROKER_USER=<user>
-BROKER_PASS=<password>
-
-# App queue
-APP_QUEUE_NAME=<queue-name>
 ```
 
 > **Obs:** Pipelines och artifacts är fullt fungerande i detta repo och kan granskas direkt via **Actions**-fliken.  

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@
 # Läser konfiguration från miljövariabler
 spring.activemq.broker-url=${BROKER_URL:tcp://activemq:61616}
 spring.activemq.user=${BROKER_USER:admin}
-spring.activemq.password=${BROKER_PASS:admin}
+spring.activemq.password=${BROKER_PASS}
 
 # Anger om pub-sub (Topic) eller point-to-point (Queue) används. false = Queue.
 spring.jms.pub-sub-domain=false
@@ -13,7 +13,7 @@ spring.jpa.open-in-view=false
 # PostgreSQL istället för H2
 spring.datasource.url=jdbc:postgresql://${DB_HOST:postgres}:${DB_PORT:5432}/${DB_NAME:integrationdb}
 spring.datasource.username=${DB_USER:integration}
-spring.datasource.password=${DB_PASSWORD:integration_pass}
+spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 # Standardport för ActiveMQ-broker.
 # Läser konfiguration från miljövariabler
 spring.activemq.broker-url=${BROKER_URL:tcp://activemq:61616}
-spring.activemq.user=${BROKER_USER:admin}
+spring.activemq.user=${BROKER_USER}
 spring.activemq.password=${BROKER_PASS}
 
 # Anger om pub-sub (Topic) eller point-to-point (Queue) används. false = Queue.


### PR DESCRIPTION
## Summary

Move local credentials out of Compose defaults and make the quickstart explicit.  
The app now consumes `DB_*` and `BROKER_*` from runtime env (via `.env`), and the docs show how to create it.

## What changed

- **docker-compose.yaml**
  - Require DB password via `${DB_PASSWORD:?Set DB_PASSWORD in .env}` (fail fast if missing).
  - Pass env into the app using `env_file: .env` so Spring picks up `DB_*`/`BROKER_*`.
  - Kept existing Swedish comments and all health checks/ports as-is.
- **docs/USAGE.md**
  - Quickstart now includes `cp .env.example .env` and a brief note on editing values.
  - Mentions Docker *and* Podman usage.

## Why

- Remove hardcoded defaults and avoid accidental empty passwords.
- Keep secrets out of VCS while preserving a smooth local dev experience.

## Impact / compatibility

- **Local dev:** After cloning, run:
  ```bash
  cp .env.example .env
  # edit DB_PASSWORD (and others) if needed
  docker compose up -d   # or: podman-compose up -d
