### PR TITLE
docs(security): add SECURITY.md with demo policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+This is a demo/portfolio repository. It is not intended for production use, but
+we still welcome responsible disclosure of security issues.
+
+## Supported Versions
+
+Only the latest `main` branch is maintained on a best-effort basis.
+
+| Version/Branch | Supported |
+|----------------|-----------|
+| `main`         | ✅        |
+| others         | ❌        |
+
+## Reporting a Vulnerability
+
+Please **do not open public issues** for security reports.
+
+- Use **GitHub Security Advisories** (preferred): “Security → Report a vulnerability”
+- Or email: igor88gomes@gmail.com
+
+We’ll acknowledge best-effort within **7 days** and keep you updated as we
+triage and address the report.
+
+## Disclosure
+
+We follow coordinated disclosure. We may request time to validate and prepare a
+fix before any public disclosure. Credit is given on request.
+
+## Out of Scope (for this demo)
+
+- Denial-of-service and volumetric attacks
+- Findings that require privileged/local access
+- CVEs only present in example/dev dependencies without a practical exploit path
+- Issues in third-party services outside this repository


### PR DESCRIPTION
Adds a SECURITY.md file to document how security reports are handled.

- Clarifies that this is a demo/portfolio repository, not for production
- Defines supported versions (only `main`, best-effort)
- Provides channels for responsible disclosure (GitHub advisories, email)
- Establishes coordinated disclosure expectations
- Lists out-of-scope items for this demo (DoS, local-only, dev CVEs, 3rd party)

This makes the repository more professional and transparent while keeping expectations realistic.
